### PR TITLE
Fix the email bugs in editJournal.php and insertJournal.php

### DIFF
--- a/php/journal/insertJournal.php
+++ b/php/journal/insertJournal.php
@@ -141,8 +141,8 @@
               $sendRes = '';
               if ($journal_created == 1) {
                 // success and send email based on $journal_created
-                require '../email/sendEmail.php';
-                require '../emailTemplate/journalCreateEmail.php';
+                require_once '../email/sendEmail.php';
+                require_once '../emailTemplate/journalCreateEmail.php';
                 $subject = getSubject();
                 $body = getBody();
                 $sendRes = sendEmail($session_uid, $email, $subject, $body, null, null);

--- a/php/journal/updateJournal.php
+++ b/php/journal/updateJournal.php
@@ -119,8 +119,8 @@
         $sendRes = '';
         if ($journal_updated == 1) {
           // success and send email based on $journal_updated
-          require '../email/sendEmail.php';
-          require '../emailTemplate/journalUpdatedEmail.php';
+          require_once '../email/sendEmail.php';
+          require_once '../emailTemplate/journalUpdatedEmail.php';
           $subject = getSubject();
           $body = getBody();
           $sendRes = sendEmail($session_uid, $email, $subject, $body, null, null);


### PR DESCRIPTION
1. change to use 'require_once "... sendEmail.php" ' to avoid the 'previously declared' error
2. fix the bugs that an alert email can't be sent out after users update an email.